### PR TITLE
refactor: getInstanceInternalをgetChildInstanceにリネーム

### DIFF
--- a/app/model/AbstractTable.php
+++ b/app/model/AbstractTable.php
@@ -232,7 +232,7 @@ abstract class AbstractTable
 	}
 
 	// プロテクテッドメソッド
-	protected static function getInstanceInternal(string $table_name): static
+	protected static function getChildInstance(string $table_name): static
 	{
 		$class = static::class;
 		if (!isset(self::$instances[$class])) {

--- a/app/model/tables/BlackoutDefinitionTable.php
+++ b/app/model/tables/BlackoutDefinitionTable.php
@@ -17,7 +17,7 @@ class BlackoutDefinitionTable extends AbstractTable
 	 */
 	public static function getInstance(): static
 	{
-		return self::getInstanceInternal('blackout_definition');
+		return self::getChildInstance('blackout_definition');
 	}
 
 	/**

--- a/app/model/tables/PjRosterTable.php
+++ b/app/model/tables/PjRosterTable.php
@@ -16,7 +16,7 @@ class PjRosterTable extends AbstractTable
 	 */
 	public static function getInstance(): static
 	{
-		return self::getInstanceInternal('pj_roster');
+		return self::getChildInstance('pj_roster');
 	}
 
 	/**

--- a/app/model/tables/PjTable.php
+++ b/app/model/tables/PjTable.php
@@ -17,7 +17,7 @@ class PjTable extends AbstractTable
 	 */
 	public static function getInstance(): static
 	{
-		return self::getInstanceInternal('pj');
+		return self::getChildInstance('pj');
 	}
 
 	/**

--- a/app/model/tables/RoomBlackoutTable.php
+++ b/app/model/tables/RoomBlackoutTable.php
@@ -18,7 +18,7 @@ class RoomBlackoutTable extends AbstractTable
 	 */
 	public static function getInstance(): static
 	{
-		return self::getInstanceInternal('room_blackout');
+		return self::getChildInstance('room_blackout');
 	}
 
 	/**

--- a/app/model/tables/RoomTable.php
+++ b/app/model/tables/RoomTable.php
@@ -16,7 +16,7 @@ class RoomTable extends AbstractTable
 	 */
 	public static function getInstance(): static
 	{
-		return self::getInstanceInternal('room');
+		return self::getChildInstance('room');
 	}
 
 	/**

--- a/app/model/tables/RsvTable.php
+++ b/app/model/tables/RsvTable.php
@@ -20,7 +20,7 @@ class RsvTable extends AbstractTable
 	 */
 	public static function getInstance(): static
 	{
-		return self::getInstanceInternal('rsv');
+		return self::getChildInstance('rsv');
 	}
 
 	/**

--- a/app/model/tables/UserTable.php
+++ b/app/model/tables/UserTable.php
@@ -15,7 +15,7 @@ class UserTable extends AbstractTable
 	 */
 	public static function getInstance(): static
 	{
-		return self::getInstanceInternal('user');
+		return self::getChildInstance('user');
 	}
 
 	// UserTableクラスはシングルトンなので、インスタンスを外部から生成できないようにします。


### PR DESCRIPTION
詳細:
- メソッド名をより意味の明確な`getChildInstance`へ変更しました。
- 既存の各テーブルクラスの`getInstance`メソッドを修正し、新しいメソッド名に対応させました。
- このリネームによる外部仕様への影響はありません。