### PR TITLE
[Issue18]Feature: PC画面ログインページ作成

### DIFF
--- a/view/pc-page/login.html
+++ b/view/pc-page/login.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    
+</body>
+</html>

--- a/view/pc-page/login.html
+++ b/view/pc-page/login.html
@@ -16,8 +16,8 @@
         <h2>ログイン</h2>
         <form action="/main_page" method="post">
             <div class="form-group">
-                <label for="wadaiid">WadaiID</label>
-                <input type="email" id="wadaiid" name="username" placeholder="x0000000@wakayama-u.ac.jp" required>
+                <label for="wadai-id">WadaiID</label>
+                <input type="email" id="wadai-id" name="username" placeholder="x0000000@wakayama-u.ac.jp" required>
             </div>
             <div class="form-group">
                 <label for="password">パスワード</label>

--- a/view/pc-page/login.html
+++ b/view/pc-page/login.html
@@ -17,7 +17,7 @@
         <form action="/main_page" method="post">
             <div class="form-group">
                 <label for="wadaiid">WadaiID</label>
-                <input type="text" id="wadaiid" name="username" required>
+                <input type="email" id="wadaiid" name="username" placeholder="x0000000@wakayama-u.ac.jp">
             </div>
             <div class="form-group">
                 <label for="password">パスワード</label>

--- a/view/pc-page/login.html
+++ b/view/pc-page/login.html
@@ -1,20 +1,33 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>PC_Login_page</title>
+    <title>ミーティングルーム予約システム - ログイン</title>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>Login Page</h1>
-    <form action="/main_page" method="post">
-        <label for="username">Username:</label>
-        <input type="text" id="username" name="username" required>
-        <br>
-        <label for="password">Password:</label>
-        <input type="password" id="password" name="password" required>
-        <br>
-        <button type="submit">Login</button>
-    </form>
+
+    <header class="page-header">
+        <h1>ミーティングルーム予約システム</h1>
+    </header>
+
+    <div class="login-container">
+        <h2>ログイン</h2>
+        <form action="/main_page" method="post">
+            <div class="form-group">
+                <label for="wadaiid">WadaiID</label>
+                <input type="text" id="wadaiid" name="username" required>
+            </div>
+            <div class="form-group">
+                <label for="password">パスワード</label>
+                <input type="password" id="password" name="password" required>
+            </div>
+            <div class="form-actions">
+                <button type="submit">ログイン</button>
+            </div>
+        </form>
+    </div>
+
 </body>
 </html>

--- a/view/pc-page/login.html
+++ b/view/pc-page/login.html
@@ -3,9 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>PC_Login_page</title>
 </head>
 <body>
-    
+    <h1>Login Page</h1>
+    <form action="/main_page" method="post">
+        <label for="username">Username:</label>
+        <input type="text" id="username" name="username" required>
+        <br>
+        <label for="password">Password:</label>
+        <input type="password" id="password" name="password" required>
+        <br>
+        <button type="submit">Login</button>
+    </form>
 </body>
 </html>

--- a/view/pc-page/login.html
+++ b/view/pc-page/login.html
@@ -17,7 +17,7 @@
         <form action="/main_page" method="post">
             <div class="form-group">
                 <label for="wadaiid">WadaiID</label>
-                <input type="email" id="wadaiid" name="username" placeholder="x0000000@wakayama-u.ac.jp">
+                <input type="email" id="wadaiid" name="username" placeholder="x0000000@wakayama-u.ac.jp" required>
             </div>
             <div class="form-group">
                 <label for="password">パスワード</label>

--- a/view/pc-page/style.css
+++ b/view/pc-page/style.css
@@ -2,12 +2,12 @@
 body {
     margin: 0;
     font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
-    background-color: #FF9900; /* 背景をオレンジ色に */
+    background-color: #f5f5f5; /* 背景を薄いグレーに */
 }
 
 /* ヘッダーのスタイル */
 .page-header {
-    background-color: #337ab7; /* ヘッダーの背景色 */
+    background-color: #f90; /* ヘッダーの背景をオレンジに */
     padding: 15px 30px;
     color: white;
 }

--- a/view/pc-page/style.css
+++ b/view/pc-page/style.css
@@ -1,0 +1,78 @@
+/* ページ全体の基本設定 */
+body {
+    margin: 0;
+    font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
+    background-color: #f5f5f5; /* 背景を薄いグレーに */
+}
+
+/* ヘッダーのスタイル */
+.page-header {
+    background-color: #337ab7; /* ヘッダーの背景色 */
+    padding: 15px 30px;
+    color: white;
+}
+
+.page-header h1 {
+    margin: 0;
+    font-size: 20px;
+}
+
+/* ログインフォームのコンテナ */
+.login-container {
+    width: 500px;
+    margin: 60px auto; /* 上下のマージンと、左右中央揃え */
+    padding: 20px 40px 40px 40px;
+    background-color: #fff;
+    border: 1px solid #ddd;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05); /* 影 */
+}
+
+/* 「ログイン」という見出しのスタイル */
+.login-container h2 {
+    font-size: 22px;
+    margin-top: 10px;
+    margin-bottom: 30px;
+}
+
+/* ラベルと入力欄のグループ */
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-group label {
+    display: block; /* ラベルをブロック要素にして改行 */
+    font-size: 14px;
+    font-weight: bold;
+    margin-bottom: 8px;
+}
+
+.form-group input {
+    width: 100%;
+    padding: 12px;
+    border: 1px solid #ccc;
+    border-radius: 4px; /* 角を少し丸める */
+    box-sizing: border-box; /* paddingを含めて幅100%にする */
+    font-size: 16px;
+}
+
+/* ボタンのスタイル */
+.form-actions {
+    text-align: right; /* ボタンを右寄せにする */
+    margin-top: 10px;
+}
+
+.form-actions button {
+    background-color: #33a9e0; /* ボタンの背景色 */
+    color: white;
+    border: none;
+    padding: 10px 30px;
+    font-size: 16px;
+    font-weight: bold;
+    border-radius: 4px;  
+    transition: background-color 0.2s;  /* ホバー時の背景色変化をスムーズにする */ 
+}
+
+/* ボタンにホバーした時のスタイル */
+.form-actions button:hover {
+    background-color: #2894c7; /* ホバー時の背景色 */
+}

--- a/view/pc-page/style.css
+++ b/view/pc-page/style.css
@@ -2,7 +2,7 @@
 body {
     margin: 0;
     font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
-    background-color: #f5f5f5; /* 背景を薄いグレーに */
+    background-color: #FF9900; /* 背景をオレンジ色に */
 }
 
 /* ヘッダーのスタイル */

--- a/view/pc-page/style.css
+++ b/view/pc-page/style.css
@@ -1,15 +1,22 @@
+/* カスタムプロパティ（変数）の定義 */
+:root {
+    --white: #fff;
+    --glay: #f5f5f5;
+    --orange: #f90;
+}
+
 /* ページ全体の基本設定 */
 body {
     margin: 0;
     font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
-    background-color: #f5f5f5; /* 背景を薄いグレーに */
+    background-color: var(--glay); /* 背景を薄いグレーに */
 }
 
 /* ヘッダーのスタイル */
 .page-header {
-    background-color: #f90; /* ヘッダーの背景をオレンジに */
+    background-color: var(--orange); /* ヘッダーの背景をオレンジに */
     padding: 15px 30px;
-    color: white;
+    color: var(--white);
 }
 
 .page-header h1 {
@@ -22,7 +29,7 @@ body {
     width: 500px;
     margin: 60px auto; /* 上下のマージンと、左右中央揃え */
     padding: 20px 40px 40px 40px;
-    background-color: #fff;
+    background-color: var(--white);
     border: 1px solid #ddd;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05); /* 影 */
 }
@@ -63,7 +70,7 @@ body {
 
 .form-actions button {
     background-color: #33a9e0; /* ボタンの背景色 */
-    color: white;
+    color: var(--white);
     border: none;
     padding: 10px 30px;
     font-size: 16px;

--- a/view/pc-page/style.css
+++ b/view/pc-page/style.css
@@ -1,22 +1,21 @@
 /* カスタムプロパティ（変数）の定義 */
 :root {
-    --white: #fff;
-    --glay: #f5f5f5;
-    --orange: #f90;
+    --background-color: #f5f5f5;
+    --theme-color: #f90;
 }
 
 /* ページ全体の基本設定 */
 body {
     margin: 0;
     font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
-    background-color: var(--glay); /* 背景を薄いグレーに */
+    background-color: var(--background-color); /* 背景を薄いグレーに */
 }
 
 /* ヘッダーのスタイル */
 .page-header {
-    background-color: var(--orange); /* ヘッダーの背景をオレンジに */
+    background-color: var(--theme-color); /* ヘッダーの背景をオレンジに */
     padding: 15px 30px;
-    color: var(--white);
+    color: #fff;
 }
 
 .page-header h1 {
@@ -29,7 +28,7 @@ body {
     width: 500px;
     margin: 60px auto; /* 上下のマージンと、左右中央揃え */
     padding: 20px 40px 40px 40px;
-    background-color: var(--white);
+    background-color: white;
     border: 1px solid #ddd;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05); /* 影 */
 }
@@ -70,7 +69,7 @@ body {
 
 .form-actions button {
     background-color: #33a9e0; /* ボタンの背景色 */
-    color: var(--white);
+    color: white;
     border: none;
     padding: 10px 30px;
     font-size: 16px;


### PR DESCRIPTION
[Issue18] PC画面ログインページ作成

## 概要

PC画面におけるログインページを作成します。

## 変更内容
### 変更を加えたファイル/クラス
- meeting-room/view/pc-page/login.html
- meeting-room/view/pc-page/index.html
- meeting-room/view/pc-page/style.css
### 実装した機能の挙動
記入欄を作成
送信ボタンを作成
ヘッダーの作成
無記入の場合送信を拒否する反応
デザインの調整

### 技術的な妥協点
index.htmlに乗せる予定のtableが完成していないため、デザインは仮のものとしている

### 当初のデザイン案

![image](https://github.com/user-attachments/assets/2d29253e-ff16-4d00-9f73-381c60c5aeed)

### 当初デザイン案からの変更点

![image](https://github.com/user-attachments/assets/19702115-8fc8-4c8c-871c-2b457e2972a0)

背景色を指定された #ff9900 に変更。
また、画面いっぱいに入力欄を表示するのではなく中央に寄せて入力欄を表示している。